### PR TITLE
[FIX] retain-cycle memory leak issue solved.

### DIFF
--- a/RAMReel/Framework/CollectionViewWrapper.swift
+++ b/RAMReel/Framework/CollectionViewWrapper.swift
@@ -103,8 +103,22 @@ open class CollectionViewWrapper
         self.theme = theme
         
         self.scrollDelegate = ScrollViewDelegate(itemHeight: collectionLayout.itemHeight)
-        
-        self.scrollDelegate.itemIndexChangeCallback = indexCallback
+        self.scrollDelegate.itemIndexChangeCallback = { [weak self] idx in
+          guard let `self` = self else { return }
+          guard let index = idx , 0 <= index && index < self.data.count else {
+            self.selectedItem = nil
+            return
+          }
+          
+          let item = self.data[index]
+          self.selectedItem = item
+          
+          // TODO: Update cell appearance maybe?
+          // Toggle selected?
+          let indexPath = IndexPath(item: index, section: 0)
+          let cell = collectionView.cellForItem(at: indexPath)
+          cell?.isSelected = true
+        }
         
         collectionView.register(CellClass.self, forCellWithReuseIdentifier: cellId)
         
@@ -138,24 +152,8 @@ open class CollectionViewWrapper
     }
     
     var selectedItem: DataType?
-    func indexCallback(_ idx: Int?) {
-        guard let index = idx , 0 <= index && index < data.count else {
-            selectedItem = nil
-            return
-        }
-        
-        let item = data[index]
-        selectedItem = item
-        
-        // TODO: Update cell appearance maybe?
-        // Toggle selected?
-        let indexPath = IndexPath(item: index, section: 0)
-        let cell = collectionView.cellForItem(at: indexPath)
-        cell?.isSelected = true
-    }
-    
+
     // MARK Implementation of WrapperProtocol
-    
     func createCell(_ collectionView: UICollectionView, indexPath: IndexPath) -> UICollectionViewCell {
         var cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellId, for: indexPath) as! CellClass
         

--- a/RAMReel/Framework/RAMReel.swift
+++ b/RAMReel/Framework/RAMReel.swift
@@ -96,7 +96,7 @@ open class RAMReel
     // MARK: TextField
     let reactor: TextFieldReactor<DataSource, CollectionWrapperClass>
     let textField: TextFieldClass
-    let returnTarget: TextFieldTarget
+    weak var returnTarget: TextFieldTarget?
     private var untouchedTarget : TextFieldTarget? = nil
     let gestureTarget: GestureTarget
     let dataFlow: DataFlow<DataSource, CollectionViewWrapper<CellClass.DataType, CellClass>>
@@ -209,7 +209,7 @@ open class RAMReel
     }
     
     var bottomConstraints: [NSLayoutConstraint] = []
-    let keyboardCallbackWrapper: NotificationCallbackWrapper
+    weak var keyboardCallbackWrapper: NotificationCallbackWrapper?
     let attemptToDodgeKeyboard : Bool
     
     // MARK: Initialization
@@ -270,7 +270,7 @@ open class RAMReel
         gestureTarget = GestureTarget()
         
         let controlEvents = UIControlEvents.editingDidEndOnExit
-        returnTarget.beTargetFor(textField, controlEvents: controlEvents) { textField -> () in
+        returnTarget?.beTargetFor(textField, controlEvents: controlEvents) { textField -> () in
             if
                 let text = textField.text,
                 let item = DataSource.ResultType.parse(text)
@@ -299,7 +299,7 @@ open class RAMReel
         
         self.untouchedTarget = TextFieldTarget(controlEvents: UIControlEvents.editingChanged, textField: self.textField, hook: {_ in s?.placeholder = "";})
         
-        self.keyboardCallbackWrapper.callback = keyboard
+        self.keyboardCallbackWrapper?.callback = keyboard
         
         updateVisuals()
         addHConstraints()


### PR DESCRIPTION
Some critical closure retain-cycle causing memory leak issues were fixed where scrollDelegate and textFieldTarget capture closure making strong reference.
****************************************************************

To give background story a little in advance, 
I am using my own customization based on reel-search for application that will be released V1.0 soon :) (named : 'All Dayz') 
Thank you for the awesome repository and I am very glad to try pull request to this.

To explain the pull request,
I fixed some critical memory leak issues caused by closure memory retain cycle.
It can be very easily reproduced if instead of existing sample example using Single ViewController, we use root-navigation controller having ViewController1 and  push ViewController2 having reel-search and back to VC1.
Using navigation controller, if we test push and pop current single ViewController example, memory is not released after pop. for example, it increases more than like 500MB after push and pop 3 times since data.txt is huge data set.
That means, this memory leak issue occurs in real project unavoidably except for the case where we only use single VC app having reel-search.

Below is the memory leak cases where I push and pop 3 times current reel-search example. 

![2018-08-30 00 32 53](https://user-images.githubusercontent.com/6975179/44798382-49960480-abec-11e8-9ad8-389a8e8cb818.png)

FYI, Memory leak retain cycles cases are categorized as 2 group as below attached : 
(1) TextFieldTarget, NotificationCallbackWrapper case
![2018-08-29 23 33 55](https://user-images.githubusercontent.com/6975179/44798162-d4c2ca80-abeb-11e8-8325-9156bc3e6dbe.png)

(2) ScrollDelegate case
![2018-08-29 23 11 25](https://user-images.githubusercontent.com/6975179/44798183-df7d5f80-abeb-11e8-8a16-356bc9ff7ba4.png)

I resolved these retain cycles and result is below with same test case above.
![2018-08-30 00 44 42](https://user-images.githubusercontent.com/6975179/44799094-181e3880-abee-11e8-86c9-4ec5eb28263e.png)

I hope it helps, Thank you!