### PR TITLE
Set selected item index even for the noScroll case.

### DIFF
--- a/RAMReel/Framework/CollectionViewWrapper.swift
+++ b/RAMReel/Framework/CollectionViewWrapper.swift
@@ -257,18 +257,23 @@ class ScrollViewDelegate: NSObject, UIScrollViewDelegate {
         
         switch scrollDirection {
         case .noScroll:
-            return
+            itemIndex = Int(floatIndex)
         case .up:
             itemIndex = Int(floor(floatIndex))
         case .down:
             itemIndex = Int(ceil(floatIndex))
         }
         
-        let adjestedOffsetY = CGFloat(itemIndex) * itemHeight - inset
-        
         if itemIndex >= 0 {
             self.itemIndex = itemIndex
         }
+        
+        // Perform no animation if no scroll is needed
+        if case .noScroll = scrollDirection {
+            return
+        }
+        
+        let adjestedOffsetY = CGFloat(itemIndex) * itemHeight - inset
         
         // Difference between actual and designated position in pixels
         let Δ = abs(scrollView.contentOffset.y - adjestedOffsetY)


### PR DESCRIPTION
Sorry, the previous pull request (https://github.com/Ramotion/reel-search/pull/27) did brake selected item functionality. There is no need to scroll, but the selected item still should be set.